### PR TITLE
Fix baseurl format in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: ⚛️ # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
 url: https://ntienhuy.github.io/AI-Thena-temp # the base hostname & protocol for your site
-baseurl:  # the subpath of your site, e.g. /blog/. Leave blank for root
+baseurl:# the subpath of your site, e.g. /blog/. Leave blank for root
 last_updated: false # set to true if you want to display last updated in the footer
 impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
 back_to_top: true # set to false to disable the back to top button


### PR DESCRIPTION
## Summary
- tweak `_config.yml` baseurl syntax

## Testing
- `npx prettier _config.yml --check` *(fails: Cannot find package '@shopify/prettier-plugin-liquid')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68835013178c83339571ad134a684853